### PR TITLE
Added UI for Logged out page

### DIFF
--- a/src/app/user/logged-out/page.tsx
+++ b/src/app/user/logged-out/page.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import Link from "next/link";
+import getServerSideSession from "@/lib/auth/ServerSession";
+import { redirect } from "next/navigation";
 
-export default function LoggedOutPage() {
+export default async function LoggedOutPage() {
+  // If logged in, redirect to /jobs dashboard
+  const session = await getServerSideSession();
+  if (session?.user) {
+    redirect("/jobs");
+  }
+
   return (
     <main className="max-w-7xl mx-auto px-5 flex items-center justify-center min-h-[80vh]">
       <div className="w-[80%] flex flex-col gap-10">


### PR DESCRIPTION
Fixes #6 

A user-friendly user interface has been added to the logged out page, with a call-to-action button that links the user back to the `/user/login` route.

Also checks for user's session, if the user is signed-in and accessing the `/user/logged-out` page, they will be redirected to their `/jobs` route dashboard.

![image](https://github.com/ParamBirje/JobsAhoy/assets/87022870/59db7596-a65e-4edb-b802-cc045f9b2789)
