### PR TITLE
Fixed: Dublin error, handled the condition for when jobsList is undef…

### DIFF
--- a/src/app/jobs/_components/views/SignedIn/JobSection.tsx
+++ b/src/app/jobs/_components/views/SignedIn/JobSection.tsx
@@ -31,7 +31,7 @@ export default function JobSection({
     <div className="flex gap-3">
       {/* Jobs List */}
       <ul className="w-1/3 h-[70vh] overflow-y-auto flex flex-col gap-3">
-        {jobsList.length > 0 ? (
+        {jobsList && jobsList.length > 0 ? (
           jobsList.map((job) => {
             return <JobCard job={job} key={job.id} />;
           })


### PR DESCRIPTION
Fixes #28 

### Cause
The location Dublin had no jobs associated with it in the database, which was the cause.

### Solution / Changes
This condition is now handled by the /jobs page, i.e by handling an `undefined` returned by the jobs list retrieved from the API call.